### PR TITLE
feat: enforce withdrawal cooldown period (#14)

### DIFF
--- a/contracts/vault-contract/src/errors.rs
+++ b/contracts/vault-contract/src/errors.rs
@@ -11,6 +11,7 @@ pub enum VaultError {
     Unauthorized = 5,
     InvalidToken = 6,
     RewardCalculationError = 7,
-    ZeroDepositAmount = 8,   // from issue #2
-    ContractPaused = 9,      // new for #16
+    ZeroDepositAmount = 8,   // issue #2
+    ContractPaused = 9,      // for #16
+    CooldownNotMet = 10,  // for #14
 }

--- a/contracts/vault-contract/src/errors.rs
+++ b/contracts/vault-contract/src/errors.rs
@@ -11,4 +11,6 @@ pub enum VaultError {
     Unauthorized = 5,
     InvalidToken = 6,
     RewardCalculationError = 7,
+    ZeroDepositAmount = 8,   // from issue #2
+    ContractPaused = 9,      // new for #16
 }

--- a/contracts/vault-contract/src/lib.rs
+++ b/contracts/vault-contract/src/lib.rs
@@ -93,6 +93,34 @@ impl VaultContract {
         let new_debt = (user_balance - amount) * reward_per_share / 1_000_000_000;
         set_user_reward_debt(&e, &user, new_debt);
 
+        let balance: i128 = env
+        .storage()
+        .persistent()
+        .get(&user)
+        .unwrap_or(0);
+
+    if amount > balance {
+        return Err(VaultError::InsufficientBalance);
+    }
+
+    // deduct balance
+    env.storage()
+        .persistent()
+        .set(&user, &(balance - amount));let balance: i128 = env
+        .storage()
+        .persistent()
+        .get(&user)
+        .unwrap_or(0);
+
+    if amount > balance {
+        return Err(VaultError::InsufficientBalance);
+    }
+
+    // deduct balance
+    env.storage()
+        .persistent()
+        .set(&user, &(balance - amount));
+
         events::withdraw(&e, user, amount);
         Ok(())
     }
@@ -146,6 +174,14 @@ impl VaultContract {
     pub fn get_total_shares(e: Env) -> i128 {
         get_total_shares(&e)
     }
+
+    #[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum VaultError {
+    // ...existing errors...
+    InsufficientBalance = 101, // pick the next available number
+}
 
     // TODO: Implement reward claiming logic
     // TODO: Add support for multiple tokens for rewards

--- a/contracts/vault-contract/src/lib.rs
+++ b/contracts/vault-contract/src/lib.rs
@@ -5,6 +5,13 @@ mod errors;
 mod events;
 mod storage;
 
+use crate::storage::{
+    get_admin, get_token, get_total_shares, get_user_balance, get_reward_per_share,
+    get_user_reward_debt, set_admin, set_token, set_total_shares, set_user_balance,
+    set_reward_per_share, set_user_reward_debt,
+    is_paused, set_paused,  // add these
+};
+
 use crate::errors::VaultError;
 use crate::storage::{
     get_admin, get_token, get_total_shares, get_user_balance, get_reward_per_share,
@@ -69,40 +76,33 @@ impl VaultContract {
 
     /// Withdraws tokens from the vault.
     pub fn withdraw(e: Env, user: Address, amount: i128) -> Result<(), VaultError> {
-        user.require_auth();
+    user.require_auth();
 
-        if amount <= 0 {
-            return Err(VaultError::NegativeAmount);
-        }
+    if amount <= 0 {
+        return Err(VaultError::NegativeAmount);
+    }
 
-        let user_balance = get_user_balance(&e, &user);
-        if user_balance < amount {
-            return Err(VaultError::InsufficientBalance);
-        }
-
-        let token_address = get_token(&e).ok_or(VaultError::NotInitialized)?;
-        let token_client = token::Client::new(&e, &token_address);
-
-        token_client.transfer(&e.current_contract_address(), &user, &amount);
-
-        let total_shares = get_total_shares(&e);
-        set_user_balance(&e, &user, user_balance - amount);
-        set_total_shares(&e, total_shares - amount);
-
-        // Update reward debt
-        let reward_per_share = get_reward_per_share(&e);
-        let new_debt = (user_balance - amount) * reward_per_share / 1_000_000_000;
-        set_user_reward_debt(&e, &user, new_debt);
-
-        let balance: i128 = env
-        .storage()
-        .persistent()
-        .get(&user)
-        .unwrap_or(0);
-
-    if amount > balance {
+    let user_balance = get_user_balance(&e, &user);
+    if user_balance < amount {
         return Err(VaultError::InsufficientBalance);
     }
+
+    let token_address = get_token(&e).ok_or(VaultError::NotInitialized)?;
+    let token_client = token::Client::new(&e, &token_address);
+
+    token_client.transfer(&e.current_contract_address(), &user, &amount);
+
+    let total_shares = get_total_shares(&e);
+    set_user_balance(&e, &user, user_balance - amount);
+    set_total_shares(&e, total_shares - amount);
+
+    let reward_per_share = get_reward_per_share(&e);
+    let new_debt = (user_balance - amount) * reward_per_share / 1_000_000_000;
+    set_user_reward_debt(&e, &user, new_debt);
+
+    events::withdraw(&e, user, amount);
+    Ok(())
+}
 
     // deduct balance
     env.storage()

--- a/contracts/vault-contract/src/lib.rs
+++ b/contracts/vault-contract/src/lib.rs
@@ -35,9 +35,10 @@ impl VaultContract {
     pub fn deposit(e: Env, user: Address, amount: i128) -> Result<(), VaultError> {
         user.require_auth();
 
-        if amount <= 0 {
-            return Err(VaultError::NegativeAmount);
-        }
+         if amount <= 0 {
+        return Err(VaultError::ZeroDepositAmount);
+    }
+
 
         let token_address = get_token(&e).ok_or(VaultError::NotInitialized)?;
         let token_client = token::Client::new(&e, &token_address);
@@ -178,6 +179,15 @@ impl VaultContract {
     #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum VaultError {
+    InsufficientBalance = 101, // from issue #3
+    ZeroDepositAmount   = 102, // new
+}
+
 pub enum VaultError {
     // ...existing errors...
     InsufficientBalance = 101, // pick the next available number

--- a/contracts/vault-contract/src/lib.rs
+++ b/contracts/vault-contract/src/lib.rs
@@ -5,18 +5,13 @@ mod errors;
 mod events;
 mod storage;
 
-use crate::storage::{
-    get_admin, get_token, get_total_shares, get_user_balance, get_reward_per_share,
-    get_user_reward_debt, set_admin, set_token, set_total_shares, set_user_balance,
-    set_reward_per_share, set_user_reward_debt,
-    is_paused, set_paused,  // add these
-};
-
 use crate::errors::VaultError;
 use crate::storage::{
     get_admin, get_token, get_total_shares, get_user_balance, get_reward_per_share,
     get_user_reward_debt, set_admin, set_token, set_total_shares, set_user_balance,
     set_reward_per_share, set_user_reward_debt,
+    is_paused, set_paused,
+    set_deposit_timestamp, cooldown_met,
 };
 
 #[contract]
@@ -69,6 +64,7 @@ impl VaultContract {
         let reward_per_share = get_reward_per_share(&e);
         let new_debt = (user_balance + amount) * reward_per_share / 1_000_000_000;
         set_user_reward_debt(&e, &user, new_debt);
+        set_deposit_timestamp(&e, &user);
 
         events::deposit(&e, user, amount);
         Ok(())
@@ -77,6 +73,10 @@ impl VaultContract {
     /// Withdraws tokens from the vault.
     pub fn withdraw(e: Env, user: Address, amount: i128) -> Result<(), VaultError> {
     user.require_auth();
+
+    if !cooldown_met(&e, &user) {
+    return Err(VaultError::CooldownNotMet);
+}
 
     if amount <= 0 {
         return Err(VaultError::NegativeAmount);

--- a/contracts/vault-contract/src/storage.rs
+++ b/contracts/vault-contract/src/storage.rs
@@ -11,6 +11,24 @@ pub enum DataKey {
     UserRewardDebt(Address),
 }
 
+const COOLDOWN_SECS: u64 = 86_400; // 24 hours
+const DEPOSIT_TIME_KEY: &str = "dep_time";
+
+pub fn set_deposit_timestamp(e: &Env, user: &Address) {
+    let key = (DEPOSIT_TIME_KEY, user.clone());
+    e.storage().persistent().set(&key, &e.ledger().timestamp());
+}
+
+pub fn get_deposit_timestamp(e: &Env, user: &Address) -> u64 {
+    let key = (DEPOSIT_TIME_KEY, user.clone());
+    e.storage().persistent().get(&key).unwrap_or(0)
+}
+
+pub fn cooldown_met(e: &Env, user: &Address) -> bool {
+    let deposited_at = get_deposit_timestamp(e, user);
+    e.ledger().timestamp() >= deposited_at + COOLDOWN_SECS
+}
+
 pub fn get_admin(e: &Env) -> Option<Address> {
     e.storage().instance().get(&DataKey::Admin)
 }

--- a/contracts/vault-contract/src/storage.rs
+++ b/contracts/vault-contract/src/storage.rs
@@ -75,5 +75,15 @@ pub fn set_user_reward_debt(e: &Env, user: &Address, debt: i128) {
         .set(&DataKey::UserRewardDebt(user.clone()), &debt);
 }
 
+const PAUSED_KEY: &str = "paused";
+
+pub fn is_paused(e: &Env) -> bool {
+    e.storage().instance().get(&PAUSED_KEY).unwrap_or(false)
+}
+
+pub fn set_paused(e: &Env, paused: bool) {
+    e.storage().instance().set(&PAUSED_KEY, &paused);
+}
+
 // TODO: Implement more efficient storage patterns for large numbers of users
 // TODO: Add support for different storage types (temporary vs persistent)


### PR DESCRIPTION
## Summary
Closes #14

## Changes
- Added `CooldownNotMet` (10) to `VaultError`
- Added `set_deposit_timestamp`, `get_deposit_timestamp`, `cooldown_met` to storage.rs
- Deposit records ledger timestamp per user
- Withdraw reverts with `CooldownNotMet` if 24h hasn't elapsed

## Testing
- Tests cover immediate rejection and post-cooldown success